### PR TITLE
Added noConflict() so multiple versions can be included in the same context safely

### DIFF
--- a/base64.js
+++ b/base64.js
@@ -10,7 +10,8 @@
 
 (function(global) {
     'use strict';
-    if (global.Base64) return;
+    // existing version for noConflict()
+    var _Base64 = global.Base64;
     var version = "2.1.2";
     // if node.js, we use Buffer
     var buffer;
@@ -141,6 +142,11 @@
                 .replace(/[^A-Za-z0-9\+\/]/g, '')
         );
     };
+    var noConflict = function() {
+        var Base64 = global.Base64;
+        global.Base64 = _Base64;
+        return Base64;
+    };
     // export Base64
     global.Base64 = {
         VERSION: version,
@@ -152,7 +158,8 @@
         encode: encode,
         encodeURI: encodeURI,
         btou: btou,
-        decode: decode
+        decode: decode,
+        noConflict: noConflict
     };
     // if ES5 is available, make Base64.extendString() available
     if (typeof Object.defineProperty === 'function') {


### PR DESCRIPTION
Hey @dankogai,

First off, thanks for your Base64 library! It's working really well for me.

I've added a `noConflict` method so that multiple versions/instances of Base64 can be included in the same context safely. I'm currently using it in a third-party JavaScript library that developers can include on their site. I don't want the Base64 version I'm using to conflict with a version already being included by the developer. Other major libraries like Underscore and jQuery include a `noConflict` method if you'd like to compare implementations.

I've only made changes to the source. I haven't minified, updated the README, or added tests. I can add tests if you'd like — I'm just not sure which test file to add to?

Let me know if you have any questions or comments. Thanks!
