### PR TITLE
enclose argument with String()

### DIFF
--- a/base64.js
+++ b/base64.js
@@ -75,8 +75,8 @@
     ;
     var encode = function(u, urisafe) {
         return !urisafe 
-            ? _encode(u)
-            : _encode(u).replace(/[+\/]/g, function(m0) {
+            ? _encode(String(u))
+            : _encode(String(u)).replace(/[+\/]/g, function(m0) {
                 return m0 == '+' ? '-' : '_';
             }).replace(/=/g, '');
     };
@@ -138,7 +138,7 @@
     : function(a) { return btou(atob(a)) };
     var decode = function(a){
         return _decode(
-            a.replace(/[-_]/g, function(m0) { return m0 == '-' ? '+' : '/' })
+            String(a).replace(/[-_]/g, function(m0) { return m0 == '-' ? '+' : '/' })
                 .replace(/[^A-Za-z0-9\+\/]/g, '')
         );
     };


### PR DESCRIPTION
Old:
```js
Base64.encode(); //~> TypeError: u is undefined
Base64.decode(); //~> TypeError: a is undefined
```
New:
```js
Base64.encode(); //=> ""
Base64.decode(); //=> ""
```