### PR TITLE
wrap require('buffer') in a try/catch for better browserify --no-builtins support

### DIFF
--- a/base64.js
+++ b/base64.js
@@ -16,7 +16,9 @@
     // if node.js, we use Buffer
     var buffer;
     if (typeof module !== 'undefined' && module.exports) {
-        buffer = require('buffer').Buffer;
+        try {
+            buffer = require('buffer').Buffer;
+        } catch (err) {}
     }
     // constants
     var b64chars


### PR DESCRIPTION
because i would like to use this library in lieu of `Buffer` and not include the entire `Buffer` module in my browserify package. right now, it throws, crashing everything. 