### PR TITLE
Update bower/base64 to match LICENSE.

### DIFF
--- a/base64.js
+++ b/base64.js
@@ -1,8 +1,8 @@
 /*
  * $Id: base64.js,v 2.15 2014/04/05 12:58:57 dankogai Exp dankogai $
  *
- *  Licensed under the MIT license.
- *    http://opensource.org/licenses/mit-license
+ *  Licensed under the BSD 3-Clause License.
+ *    http://opensource.org/licenses/BSD-3-Clause
  *
  *  References:
  *    http://en.wikipedia.org/wiki/Base64

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,7 @@
 {
   "name": "js-base64",
   "version": "2.1.9",
+  "license": "BSD",
   "main": [
     "./base64.js"
   ],


### PR DESCRIPTION
Solves #18 based on previously accepted PR #20, which indicates BSD.