### PR TITLE
Add support for ES2015 Modules, AMD and node module.exports

### DIFF
--- a/base64.js
+++ b/base64.js
@@ -191,4 +191,15 @@
     if (global['Meteor']) {
        Base64 = global.Base64; // for normal export in Meteor.js
     }
-})(this);
+	if (typeof module !== 'undefined' && module.exports) {
+		module.exports.Base64 = global.Base64;
+	}
+	if (typeof define === 'function' && define.amd) {
+		// AMD. Register as an anonymous module.
+		define([], function(){ return global.Base64 });
+	}
+})(	typeof self !== 'undefined' ? self
+	: typeof window !== 'undefined' ? window
+		: typeof global !== 'undefined' ? global
+			: this
+);

--- a/base64.js
+++ b/base64.js
@@ -198,7 +198,7 @@
 		// AMD. Register as an anonymous module.
 		define([], function(){ return global.Base64 });
 	}
-})(	typeof self !== 'undefined' ? self
+})(typeof self !== 'undefined' ? self
 	: typeof window !== 'undefined' ? window
 		: typeof global !== 'undefined' ? global
 			: this

--- a/base64.js
+++ b/base64.js
@@ -189,17 +189,17 @@
     }
     // that's it!
     if (global['Meteor']) {
-       Base64 = global.Base64; // for normal export in Meteor.js
+        Base64 = global.Base64; // for normal export in Meteor.js
     }
-	if (typeof module !== 'undefined' && module.exports) {
-		module.exports.Base64 = global.Base64;
-	}
-	if (typeof define === 'function' && define.amd) {
-		// AMD. Register as an anonymous module.
-		define([], function(){ return global.Base64 });
-	}
+    if (typeof module !== 'undefined' && module.exports) {
+        module.exports.Base64 = global.Base64;
+    }
+    if (typeof define === 'function' && define.amd) {
+        // AMD. Register as an anonymous module.
+        define([], function(){ return global.Base64 });
+    }
 })(typeof self !== 'undefined' ? self
-	: typeof window !== 'undefined' ? window
-		: typeof global !== 'undefined' ? global
-			: this
+ : typeof window !== 'undefined' ? window
+ : typeof global !== 'undefined' ? global
+ : this
 );


### PR DESCRIPTION
Hi,

This plugin is used by **a lot** of users (**4 245 947 downloads in the last month**), yet many old issues are still open regarding the top-level `this` expression. This PR should fix almost all of these:
https://github.com/dankogai/js-base64/issues/25
https://github.com/dankogai/js-base64/issues/33
https://github.com/dankogai/js-base64/issues/42
https://github.com/dankogai/js-base64/issues/45

Thanks !