### PR TITLE
Add buffer as NPM dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,22 @@
+{
+  "name": "js-base64",
+  "version": "2.3.2",
+  "lockfileVersion": 1,
+  "dependencies": {
+    "base64-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.1.tgz",
+      "integrity": "sha512-dwVUVIXsBZXwTuwnXI9RK8sBmgq09NDHzyR9SAph9eqk76gKK2JSQmZARC2zRC81JC2QTtxD0ARU5qTS25gIGw=="
+    },
+    "buffer": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.0.8.tgz",
+      "integrity": "sha512-xXvjQhVNz50v2nPeoOsNqWCLGfiv4ji/gXZM28jnVwdLJxH4mFyqgqCKfaK9zf1KUbG6zTkjLOy7ou+jSMarGA=="
+    },
+    "ieee754": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz",
+      "integrity": "sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -22,5 +22,8 @@
   "author": "Dan Kogai",
   "license": "BSD-3-Clause",
   "readmeFilename": "README.md",
-  "gitHead": "8bfa436f733bec60c95c720e1d720c28b43ae0b2"
+  "gitHead": "8bfa436f733bec60c95c720e1d720c28b43ae0b2",
+  "dependencies": {
+    "buffer": "^5.0.8"
+  }
 }


### PR DESCRIPTION
`buffer` is an unlisted dependency for this project, so it causes errors in node environments that don't have it by default or through another library, such as in React Native.

Also adds a package lock file.