### PR TITLE
added buffer node module

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
   "scripts": {
     "test": "mocha"
   },
+  "dependencies": {
+    "buffer": "5.0.8"
+  },
   "devDependencies": {
     "mocha": "*"
   },


### PR DESCRIPTION
Hi @dankogai,

I have added buffer@5.0.8 node module to package.json

After installing this library, I was getting exception that buffer module not found. Based on  investigating I found that the buffer node module was not added in dependencies list

Can you please merge the raised PR. Please let me know in case any changes or discussion is required for the same

Thanks
Pranav