### PR TITLE
2.4.5 includes test/index.html,v in the packed tgz

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,5 @@
 .babelrc
 .eslintrc
 .travis.yml
-.*,v
+*,v
 *.bak

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-base64",
-  "version": "2.4.5",
+  "version": "2.4.6",
   "description": "Yet another Base64 transcoder in pure-JS",
   "main": "base64.js",
   "directories": {


### PR DESCRIPTION
Tested using `npm pack` and `tar tf` 

before with https://registry.npmjs.org/js-base64/-/js-base64-2.4.5.tgz
package/test/index.html
package/test/index.html,v

