### PR TITLE
bugfix: when `global` is undefined.

### DIFF
--- a/base64.js
+++ b/base64.js
@@ -20,6 +20,7 @@
 ), function(global) {
     'use strict';
     // existing version for noConflict()
+    global = global || {};
     var _Base64 = global.Base64;
     var version = "2.5.0";
     // if node.js and NOT React Native, we use Buffer


### PR DESCRIPTION
Some JavaScript runtime may missing the `global` target, which mean it can be `undefined`, so fix it here.

NOTE: I have no idea how to build `base64.min.js` file and no clue in package.json, so I did not update it in this PR. :(