### PR TITLE
Revert "Replace eval with navigator test to detect react native"

### DIFF
--- a/base64.js
+++ b/base64.js
@@ -25,9 +25,9 @@
     var version = "2.5.1";
     // if node.js and NOT React Native, we use Buffer
     var buffer;
-    if (typeof module !== 'undefined' && module.exports && (typeof navigator === "undefined" || navigator.product !== 'ReactNative')) {
+    if (typeof module !== 'undefined' && module.exports) {
         try {
-            buffer = require('buffer').Buffer;
+            buffer = eval("require('buffer').Buffer");
         } catch (err) {
             buffer = undefined;
         }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "devDependencies": {
     "babel-preset-env": "^1.7.0",
     "babel-register": "^6.26.0",
-    "mocha": "5.x.x"
+    "mocha": "*"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Reverts dankogai/js-base64#90. See https://github.com/dankogai/js-base64/issues/82 for the reason