### PR TITLE
Fix WhiteSource warnings 

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -3,3 +3,4 @@
 .travis.yml
 *,v
 *.bak
+test/**/*

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-base64",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "description": "Yet another Base64 transcoder in pure-JS",
   "main": "base64.js",
   "directories": {


### PR DESCRIPTION
- Add `test` folder to `.npmignore` to fix issue #93 
- Update package version to 2.5.2 