### PR TITLE
Update base64.html for Parse exception

### DIFF
--- a/base64.html
+++ b/base64.html
@@ -22,7 +22,7 @@
 </tr>
 <tr><th width="50%">Roundtrip</th><th>iframe w/ data: (no IE)</th></tr>
 <tr>
-<th><textarea id="roundtrip" cols=32" rows="4" disabled></textarea></th>
+<th><textarea id="roundtrip" cols="32" rows="4" disabled></textarea></th>
 <th><iframe id="data" width="80%" height="64"></iframe></th>
 </tr>
 </tbody></table>


### PR DESCRIPTION
HTML is missing a double quotation resulting in parse exception during minification