### PR TITLE
Bug: when minifying the regex becomes bad.

### DIFF
--- a/base64.js
+++ b/base64.js
@@ -97,11 +97,7 @@
     };
     var encodeURI = function(u) { return encode(u, true) };
     // decoder stuff
-    var re_btou = new RegExp([
-        '[\xC0-\xDF][\x80-\xBF]',
-        '[\xE0-\xEF][\x80-\xBF]{2}',
-        '[\xF0-\xF7][\x80-\xBF]{3}'
-    ].join('|'), 'g');
+    var re_btou = /[\xC0-\xDF][\x80-\xBF]|[\xE0-\xEF][\x80-\xBF]{2}|[\xF0-\xF7][\x80-\xBF]{3}/g;
     var cb_btou = function(cccc) {
         switch(cccc.length) {
         case 4:


### PR DESCRIPTION
When not using a string, the regex seems to still work. I know it is probably caused by the minifier, but it was easier to fix here.