### PR TITLE
Update package.json to support later versions of TypeScript

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   ],
   "exports": {
     ".": {
+      "types": "./base64.d.ts",
       "import": "./base64.mjs",
       "require": "./base64.js"
     },


### PR DESCRIPTION
Currently, when using js-base64 with ESM and Node16 "moduleResolution" in TypeScript, TypeScript is unable to resolve the types because it resolves `base64.mjs` in ESM mode and checks for a definition file named `base64.d.mts`, which doesn't exist.

I fixed this by adding an explicit "types" property that points to `base64.d.ts` inside the "exports" property, based on the screenshot of the docs below (screenshot from https://www.typescriptlang.org/docs/handbook/esm-node.html):
![image](https://user-images.githubusercontent.com/36966635/202274693-6b2e1407-c3d1-47c8-a628-360853c2fff5.png)
