### PR TITLE
ADD sideEffects:false

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "base64.js",
   "module": "base64.mjs",
   "types": "base64.d.ts",
+  "sideEffects": false,
   "files": [
     "base64.js",
     "base64.mjs",


### PR DESCRIPTION
This PR sets `sideEffects: false` in the package.json.
That will give webpack a hint to better bundle this library and to run tree shaking.
It anyway exports a pure function that has no side effect on importing.

From https://webpack.js.org/guides/tree-shaking/#mark-the-file-as-side-effect-free : 

>  The new webpack 4 release expands on this capability with a way to provide hints to the compiler via the "sideEffects" package.json property to denote which files in your project are "pure" and therefore safe to prune if unused.