### PR TITLE
Caching the result of atob existence is causing web worker to crash

### DIFF
--- a/base64.js
+++ b/base64.js
@@ -42,8 +42,8 @@
      * @deprecated use lowercase `version`.
      */
     var VERSION = version;
-    var _hasatob = typeof atob === 'function';
-    var _hasbtoa = typeof btoa === 'function';
+    var typeof atob === 'function' = typeof atob === 'function';
+    var typeof btoa === 'function' = typeof btoa === 'function';
     var _hasBuffer = typeof Buffer === 'function';
     var _TD = typeof TextDecoder === 'function' ? new TextDecoder() : undefined;
     var _TE = typeof TextEncoder === 'function' ? new TextEncoder() : undefined;
@@ -87,7 +87,7 @@
      * @param {String} bin binary string
      * @returns {string} Base64-encoded string
      */
-    var _btoa = _hasbtoa ? function (bin) { return btoa(bin); }
+    var _btoa = typeof btoa === 'function' ? function (bin) { return btoa(bin); }
         : _hasBuffer ? function (bin) { return Buffer.from(bin, 'binary').toString('base64'); }
             : btoaPolyfill;
     var _fromUint8Array = _hasBuffer
@@ -216,7 +216,7 @@
      * @param {String} asc Base64-encoded string
      * @returns {string} binary string
      */
-    var _atob = _hasatob ? function (asc) { return atob(_tidyB64(asc)); }
+    var _atob = typeof atob === 'function' ? function (asc) { return atob(_tidyB64(asc)); }
         : _hasBuffer ? function (asc) { return Buffer.from(asc, 'base64').toString('binary'); }
             : atobPolyfill;
     //

--- a/base64.mjs
+++ b/base64.mjs
@@ -14,8 +14,6 @@ const version = '3.7.6';
  * @deprecated use lowercase `version`.
  */
 const VERSION = version;
-const _hasatob = typeof atob === 'function';
-const _hasbtoa = typeof btoa === 'function';
 const _hasBuffer = typeof Buffer === 'function';
 const _TD = typeof TextDecoder === 'function' ? new TextDecoder() : undefined;
 const _TE = typeof TextEncoder === 'function' ? new TextEncoder() : undefined;
@@ -59,7 +57,7 @@ const btoaPolyfill = (bin) => {
  * @param {String} bin binary string
  * @returns {string} Base64-encoded string
  */
-const _btoa = _hasbtoa ? (bin) => btoa(bin)
+const _btoa = typeof btoa === 'function' ? (bin) => btoa(bin)
     : _hasBuffer ? (bin) => Buffer.from(bin, 'binary').toString('base64')
         : btoaPolyfill;
 const _fromUint8Array = _hasBuffer
@@ -182,7 +180,7 @@ const atobPolyfill = (asc) => {
  * @param {String} asc Base64-encoded string
  * @returns {string} binary string
  */
-const _atob = _hasatob ? (asc) => atob(_tidyB64(asc))
+const _atob = typeof atob === 'function' ? (asc) => atob(_tidyB64(asc))
     : _hasBuffer ? (asc) => Buffer.from(asc, 'base64').toString('binary')
         : atobPolyfill;
 //

--- a/base64.ts
+++ b/base64.ts
@@ -14,8 +14,6 @@ const version = '3.7.6';
  * @deprecated use lowercase `version`.
  */
 const VERSION = version;
-const _hasatob = typeof atob === 'function';
-const _hasbtoa = typeof btoa === 'function';
 const _hasBuffer = typeof Buffer === 'function';
 const _TD = typeof TextDecoder === 'function' ? new TextDecoder() : undefined;
 const _TE = typeof TextEncoder === 'function' ? new TextEncoder() : undefined;
@@ -61,7 +59,7 @@ const btoaPolyfill = (bin: string) => {
  * @param {String} bin binary string
  * @returns {string} Base64-encoded string
  */
-const _btoa = _hasbtoa ? (bin: string) => btoa(bin)
+const _btoa = typeof btoa === 'function' ? (bin: string) => btoa(bin)
     : _hasBuffer ? (bin: string) => Buffer.from(bin, 'binary').toString('base64')
         : btoaPolyfill;
 const _fromUint8Array = _hasBuffer
@@ -188,7 +186,7 @@ const atobPolyfill = (asc: string) => {
  * @param {String} asc Base64-encoded string
  * @returns {string} binary string
  */
-const _atob = _hasatob ? (asc: string) => atob(_tidyB64(asc))
+const _atob = typeof atob === 'function' ? (asc: string) => atob(_tidyB64(asc))
     : _hasBuffer ? (asc: string) => Buffer.from(asc, 'base64').toString('binary')
         : atobPolyfill;
 //


### PR DESCRIPTION
Hi,

Awesome library, I use it in all my projects.

recently I used this library in a web app that launches a web worker, the issue occurred when _hasatob is calculated when app is loaded on the main thread (while atob) exists and when running the web worker it mistakenly fails because it does not exist.

by not caching the result it solves the issue
