### PR TITLE
fix: preserve leading BOM (U+FEFF) on the TextDecoder decode path

### DIFF
--- a/base64.js
+++ b/base64.js
@@ -43,7 +43,7 @@
      */
     var VERSION = version;
     var _hasBuffer = typeof Buffer === 'function';
-    var _TD = typeof TextDecoder === 'function' ? new TextDecoder() : undefined;
+    var _TD = typeof TextDecoder === 'function' ? new TextDecoder('utf-8', { ignoreBOM: true }) : undefined;
     var _TE = typeof TextEncoder === 'function' ? new TextEncoder() : undefined;
     var b64ch = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=';
     var b64chs = Array.prototype.slice.call(b64ch);

--- a/base64.mjs
+++ b/base64.mjs
@@ -15,7 +15,7 @@ const version = '3.7.8';
  */
 const VERSION = version;
 const _hasBuffer = typeof Buffer === 'function';
-const _TD = typeof TextDecoder === 'function' ? new TextDecoder() : undefined;
+const _TD = typeof TextDecoder === 'function' ? new TextDecoder('utf-8', { ignoreBOM: true }) : undefined;
 const _TE = typeof TextEncoder === 'function' ? new TextEncoder() : undefined;
 const b64ch = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=';
 const b64chs = Array.prototype.slice.call(b64ch);

--- a/base64.ts
+++ b/base64.ts
@@ -15,7 +15,7 @@ const version = '3.7.8';
  */
 const VERSION = version;
 const _hasBuffer = typeof Buffer === 'function';
-const _TD = typeof TextDecoder === 'function' ? new TextDecoder() : undefined;
+const _TD = typeof TextDecoder === 'function' ? new TextDecoder('utf-8', { ignoreBOM: true }) : undefined;
 const _TE = typeof TextEncoder === 'function' ? new TextEncoder() : undefined;
 const b64ch =
     'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=';

--- a/test/bom.js
+++ b/test/bom.js
@@ -1,0 +1,39 @@
+/*
+ * use mocha to test me
+ * http://visionmedia.github.com/mocha/
+ *
+ * Decode must preserve a leading U+FEFF (BOM) on the TextDecoder path,
+ * matching the Buffer and atob-polyfill paths.
+ */
+var assert = assert || require("assert");
+
+// Load Base64 in a browser-faithful environment: no Buffer, no atob/btoa,
+// but TextDecoder/TextEncoder present, so the TextDecoder decode path is taken.
+var Base64 = (function () {
+    var savedBuffer = global.Buffer;
+    var savedAtob = global.atob;
+    var savedBtoa = global.btoa;
+    global.Buffer = undefined;
+    global.atob = undefined;
+    global.btoa = undefined;
+    delete require.cache[require.resolve('../base64.js')];
+    var B64 = require('../base64.js').Base64;
+    delete require.cache[require.resolve('../base64.js')];
+    global.Buffer = savedBuffer;
+    global.atob = savedAtob;
+    global.btoa = savedBtoa;
+    return B64;
+})();
+
+var is = function (a, e, m) {
+    return function () {
+        assert.equal(a, e, m)
+    }
+};
+
+describe('BOM (TextDecoder path)', function () {
+    var bom = '﻿';
+    it('decode keeps a leading BOM', is(Base64.decode('77u/aGVsbG8='), bom + 'hello'));
+    it('round-trips a leading BOM', is(Base64.decode(Base64.encode(bom + 'hello')), bom + 'hello'));
+    it('round-trips a lone BOM', is(Base64.decode(Base64.encode(bom)), bom));
+});


### PR DESCRIPTION
### Problem

A leading `U+FEFF` (BOM) is dropped on decode when the `TextDecoder` code path is taken (browsers, and Node when the `Buffer` path is not available). This breaks the `decode(encode(s)) === s` contract for any string that starts with a BOM.

```js
Base64.encode('﻿hello');   // "77u/aGVsbG8="  (RFC-correct: bytes EF BB BF 68 65 6C 6C 6F)
Base64.decode('77u/aGVsbG8=');  // "hello"  -- WRONG, leading U+FEFF lost; expected "﻿hello"
```

`toUint8Array` returns the correct bytes (`[239, 187, 191, 104, 101, 108, 108, 111]`), so the loss is purely in the bytes-to-string step.

### Buffer oracle vs TextDecoder path

The same decoded bytes round-trip correctly through the `Buffer` path but not through the `TextDecoder` path:

```js
const bytes = Base64.toUint8Array('77u/aGVsbG8=');           // EF BB BF 68 65 6C 6C 6F
Buffer.from('77u/aGVsbG8=', 'base64').toString('utf8');      // "﻿hello"  (length 6)  correct
new TextDecoder().decode(bytes);                             // "hello"        (length 5)  BOM dropped
new TextDecoder('utf-8', { ignoreBOM: true }).decode(bytes); // "﻿hello"  (length 6)  correct
```

The README documents `decode` as the UTF-8 inverse of `encode` (`Base64.decode('5bCP6aO85by+') // 小飼弾`), so a leading BOM should survive the round trip just like any other character.

### Root cause

`base64.ts` builds the shared decoder with default options:

```ts
const _TD = typeof TextDecoder === 'function' ? new TextDecoder() : undefined;
```

`TextDecoder` defaults to `ignoreBOM: false`, which makes it consume a leading BOM. So on the `_TD` decode path (`_TD.decode(_toUint8Array(a))`), the first `U+FEFF` is stripped. The `Buffer` path (`Buffer.from(...).toString('utf8')`) and the `atob` polyfill path (`btou(_atob(...))`) both keep it, so the lib is internally inconsistent depending on which path runs.

### Fix

Construct the decoder with `ignoreBOM: true` so the BOM is treated as ordinary content:

```ts
const _TD = typeof TextDecoder === 'function' ? new TextDecoder('utf-8', { ignoreBOM: true }) : undefined;
```

This aligns the `TextDecoder` path with the `Buffer` and polyfill paths. The dist artifacts (`base64.js`, `base64.mjs`) were regenerated via `make all` so the shipped output matches the source.

### Test

Added `test/bom.js`, which loads `Base64` in a browser-faithful environment (no `Buffer`, no `atob`/`btoa`, `TextDecoder` present) to exercise the `TextDecoder` decode path, and asserts the BOM survives decode and round trips.

- Red before the fix: the three BOM assertions fail (BOM dropped, length 5 vs 6).
- Green after the fix: `101 passing` for the full suite (`make clean && make test`), including the three new BOM cases.
