### PR TITLE
fix: throw on non-Latin1 input in the Buffer btoa fallback

### DIFF
--- a/base64.js
+++ b/base64.js
@@ -86,7 +86,11 @@
      * @returns {string} Base64-encoded string
      */
     var _btoa = typeof btoa === 'function' ? function (bin) { return btoa(bin); }
-        : _hasBuffer ? function (bin) { return Buffer.from(bin, 'binary').toString('base64'); }
+        : _hasBuffer ? function (bin) {
+            if (/[^\x00-\xff]/.test(bin))
+                throw new TypeError('invalid character found');
+            return Buffer.from(bin, 'binary').toString('base64');
+        }
             : btoaPolyfill;
     var _fromUint8Array = _hasBuffer
         ? function (u8a) { return Buffer.from(u8a).toString('base64'); }

--- a/base64.mjs
+++ b/base64.mjs
@@ -58,7 +58,11 @@ const btoaPolyfill = (bin) => {
  * @returns {string} Base64-encoded string
  */
 const _btoa = typeof btoa === 'function' ? (bin) => btoa(bin)
-    : _hasBuffer ? (bin) => Buffer.from(bin, 'binary').toString('base64')
+    : _hasBuffer ? (bin) => {
+        if (/[^\x00-\xff]/.test(bin))
+            throw new TypeError('invalid character found');
+        return Buffer.from(bin, 'binary').toString('base64');
+    }
         : btoaPolyfill;
 const _fromUint8Array = _hasBuffer
     ? (u8a) => Buffer.from(u8a).toString('base64')

--- a/base64.ts
+++ b/base64.ts
@@ -60,7 +60,11 @@ const btoaPolyfill = (bin: string) => {
  * @returns {string} Base64-encoded string
  */
 const _btoa = typeof btoa === 'function' ? (bin: string) => btoa(bin)
-    : _hasBuffer ? (bin: string) => Buffer.from(bin, 'binary').toString('base64')
+    : _hasBuffer ? (bin: string) => {
+        if (/[^\x00-\xff]/.test(bin))
+            throw new TypeError('invalid character found');
+        return Buffer.from(bin, 'binary').toString('base64');
+    }
         : btoaPolyfill;
 const _fromUint8Array = _hasBuffer
     ? (u8a: Uint8Array) => Buffer.from(u8a).toString('base64')

--- a/test/btoa-buffer.js
+++ b/test/btoa-buffer.js
@@ -1,0 +1,32 @@
+/*
+ * use mocha to test me
+ * http://visionmedia.github.com/mocha/
+ *
+ * Base64.btoa must throw on characters outside Latin-1 (0-255), the same as
+ * window.btoa and Base64.btoaPolyfill.  This checks the Buffer fallback path,
+ * taken when Buffer exists but global btoa does not (e.g. node.js < 16).
+ */
+var assert = assert || require("assert");
+
+// Load Base64 with Buffer present but no atob/btoa, so _btoa uses the Buffer path.
+var Base64 = (function () {
+    var savedAtob = global.atob;
+    var savedBtoa = global.btoa;
+    global.atob = undefined;
+    global.btoa = undefined;
+    delete require.cache[require.resolve('../base64.js')];
+    var B64 = require('../base64.js').Base64;
+    delete require.cache[require.resolve('../base64.js')];
+    global.atob = savedAtob;
+    global.btoa = savedBtoa;
+    return B64;
+})();
+
+describe('btoa (Buffer fallback)', function () {
+    it('encodes Latin-1 the same as standard Base64', function () {
+        assert.equal(Base64.btoa('dankogai'), 'ZGFua29nYWk=');
+    });
+    it('throws on a character outside Latin-1', function () {
+        assert.throws(function () { Base64.btoa('小飼弾'); }, TypeError);
+    });
+});


### PR DESCRIPTION
`Base64.btoa` is documented to raise on characters outside Latin-1 (SYNOPSIS: `Base64.btoa(utf8); // raises exception`). The native `btoa` branch and `btoaPolyfill` both throw. The Buffer fallback, used when `Buffer` exists but a global `btoa` does not (node.js before 16, and some bundler or SSR setups that polyfill `Buffer` only), did not: it passed the string to `Buffer.from(bin, 'binary')`, which truncates each code unit to its low byte, so `Base64.btoa('小飼弾')` returned `"D/w+"` instead of throwing.

This rejects any character above U+00FF before encoding on the Buffer path, so the three `btoa` implementations behave the same. Adds a test that loads the module with `Buffer` present and `atob`/`btoa` removed and asserts the throw.
